### PR TITLE
Feat/calendar/buttons

### DIFF
--- a/src/pages/app/index.js
+++ b/src/pages/app/index.js
@@ -1,15 +1,35 @@
-import React from 'react';
-import { Calendar } from 'antd';
+import React, { useState } from 'react';
+import { Calendar, Drawer, Button } from 'antd';
+import { PlusOutlined } from '@ant-design/icons';
 
 import App, { AppPages } from '../../components/App';
 import SEO from '../../components/SEO';
 
 function IndexPage() {
+	const [pickupRequestOpen, setPickupRequestOpen] = useState(false);
+
 	return (
 		<App pageId={AppPages.Calendar}>
 			<SEO title="Meal Matchup" description="" />
 
-			<Calendar />
+			<div className="events-calendar">
+				<Calendar />
+
+				<div className="calendar-buttons-container">
+					<Button type="primary" onClick={() => setPickupRequestOpen(true)}>
+						<PlusOutlined /> New Pickup Request
+					</Button>
+				</div>
+
+				<Drawer
+					className="drawer"
+					title="New Pickup Request"
+					visible={pickupRequestOpen}
+					onClose={() => setPickupRequestOpen(false)}
+				>
+					<p>Put pickup request form here</p>
+				</Drawer>
+			</div>
 		</App>
 	);
 }

--- a/src/styles/design.scss
+++ b/src/styles/design.scss
@@ -2,3 +2,4 @@
 @import './inc/mixins';
 @import './inc/base';
 @import './inc/components/components';
+@import './inc/content/content';

--- a/src/styles/inc/components/_components.scss
+++ b/src/styles/inc/components/_components.scss
@@ -1,4 +1,5 @@
 @import './graphics';
 @import './layout';
 @import './auth';
+@import './drawer';
 @import './gatsby';

--- a/src/styles/inc/components/_drawer.scss
+++ b/src/styles/inc/components/_drawer.scss
@@ -1,0 +1,9 @@
+.drawer.ant-drawer-open {
+	& > .ant-drawer-content-wrapper {
+		@include breakpoint(md) {
+			width: 720px !important;
+		}
+
+		width: 100% !important;
+	}
+}

--- a/src/styles/inc/content/_calendar.scss
+++ b/src/styles/inc/content/_calendar.scss
@@ -1,0 +1,12 @@
+.calendar-buttons-container {
+	bottom: 1em;
+	display: flex;
+	flex-direction: column;
+	position: fixed;
+	right: 1em;
+	z-index: 2;
+
+	button {
+		margin-top: 1em;
+	}
+}

--- a/src/styles/inc/content/_content.scss
+++ b/src/styles/inc/content/_content.scss
@@ -1,0 +1,1 @@
+@import './calendar';


### PR DESCRIPTION
Adds a basic base for buttons that open drawers on the calendar page.
Provides starting point for creating pickup requests, delivery requests, and bag'n'tag requests.